### PR TITLE
fix: Correct TypeScript error in ScreenshotHelper

### DIFF
--- a/electron/ScreenshotHelper.ts
+++ b/electron/ScreenshotHelper.ts
@@ -96,11 +96,10 @@ export class ScreenshotHelper {
           exec(`screencapture -C "${screenshotPath}"`, (error, stdout, stderr) => {
             if (error) {
               console.error('Error using screencapture:', error);
-              // Attempt fallback to original method or reject
-              // For now, let's try to fallback to existing screenshot() if screencapture fails
-              screenshot({ filename: screenshotPath }).then(resolve).catch(reject);
-              // Alternatively, to strictly use screencapture and report error:
-              // return reject(error);
+              // Attempt fallback to original method
+              screenshot({ filename: screenshotPath })
+                .then(() => resolve()) // Corrected line: resolve called with no arguments
+                .catch(reject);
             } else {
               resolve();
             }


### PR DESCRIPTION
The previous commit introduced a TypeScript type error in `electron/ScreenshotHelper.ts` within the fallback logic for macOS screenshots. The `resolve` function of a `Promise<void>` was being called with the result of `screenshot-desktop` (a string), causing a type mismatch.

This commit corrects the issue by changing the call from: `screenshot({ filename: screenshotPath }).then(resolve).catch(reject);` to:
`screenshot({ filename: screenshotPath }).then(() => resolve()).catch(reject);`

This ensures `resolve()` is called without arguments, satisfying the `Promise<void>` type requirement.